### PR TITLE
Added meta files for dune-release lint

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,6 @@
+# Changelog
+===========
+
+## [0.1] - January 14, 2021
+### Added
+- Meta files for dune release 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License
+
+Copyright 2021 Sadiq Jaffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rungen.opam
+++ b/rungen.opam
@@ -5,7 +5,13 @@ synopsis: "Generates dune files to run benchmarks from centralised config"
 maintainer: "Sadiq Jaffer <sadiq@toao.com>"
 authors: "Sadiq Jaffer <sadiq@toao.com>"
 license: "MIT"
+homepage: "https://github.com/ocaml-bench/rungen"
+bug-reports: "https://github.com/ocaml-bench/rungen/issues"
 depends: [ "ocaml" "yojson" "sexplib0" ]
 build: [
   ["dune" "build" "-p" name]
 ]
+description: """
+The rungen utility generates dune files to execute
+[Sandmark](https://github.com/ocaml-bench/sandmark) benchmarks.
+"""


### PR DESCRIPTION
Additional meta files and .opam have been updated to prepare the sources for a release to opam.ocaml.org.